### PR TITLE
feat: add editable cards grid

### DIFF
--- a/scorekeeper/src/app/pages/cards/cards.html
+++ b/scorekeeper/src/app/pages/cards/cards.html
@@ -1,5 +1,10 @@
 <div class="cards-scoring-wrapper">
-    <p-table [value]="playerData" [tableStyle]="{ 'min-width': '50rem' }">
+    <p-table
+        [value]="playerData"
+        editMode="cell"
+        (onEditComplete)="onEditComplete()"
+        [tableStyle]="{ 'min-width': '50rem' }"
+    >
         <ng-template #header>
             <tr>
                 <th>Name</th>
@@ -12,18 +17,33 @@
                 <td [pEditableColumn]="player.name" pEditableColumnField="name">
                     <p-cellEditor>
                         <ng-template #input>
-                            <input
-                                pInputText
-                                type="text"
-                                fluid />
+                            <input pInputText type="text" fluid />
                         </ng-template>
                         <ng-template #output>
                             {{ player.name }}
                         </ng-template>
                     </p-cellEditor>
                 </td>
-                <td>{{ player.points }}</td>
-                <td>{{ player.notes }}</td>
+                <td [pEditableColumn]="player.points" pEditableColumnField="points">
+                    <p-cellEditor>
+                        <ng-template #input>
+                            <input pInputText type="number" fluid />
+                        </ng-template>
+                        <ng-template #output>
+                            {{ player.points }}
+                        </ng-template>
+                    </p-cellEditor>
+                </td>
+                <td [pEditableColumn]="player.notes" pEditableColumnField="notes">
+                    <p-cellEditor>
+                        <ng-template #input>
+                            <input pInputText type="text" fluid />
+                        </ng-template>
+                        <ng-template #output>
+                            {{ player.notes }}
+                        </ng-template>
+                    </p-cellEditor>
+                </td>
             </tr>
         </ng-template>
     </p-table>

--- a/scorekeeper/src/app/pages/cards/cards.html
+++ b/scorekeeper/src/app/pages/cards/cards.html
@@ -2,7 +2,7 @@
     <p-table
         [value]="playerData"
         editMode="cell"
-        (onEditComplete)="onEditComplete()"
+        (onEditComplete)="onEditComplete($event)"
         [tableStyle]="{ 'min-width': '50rem' }"
     >
         <ng-template #header>
@@ -14,7 +14,7 @@
         </ng-template>
         <ng-template #body let-player let-i="index">
             <tr>
-                <td [pEditableColumn]="player.name" pEditableColumnField="name">
+                <td pEditableColumn pEditableColumnField="name">
                     <p-cellEditor>
                         <ng-template #input>
                             <input pInputText type="text" fluid />
@@ -24,7 +24,7 @@
                         </ng-template>
                     </p-cellEditor>
                 </td>
-                <td [pEditableColumn]="player.points" pEditableColumnField="points">
+                <td pEditableColumn pEditableColumnField="points">
                     <p-cellEditor>
                         <ng-template #input>
                             <input pInputText type="number" fluid />
@@ -34,7 +34,7 @@
                         </ng-template>
                     </p-cellEditor>
                 </td>
-                <td [pEditableColumn]="player.notes" pEditableColumnField="notes">
+                <td pEditableColumn pEditableColumnField="notes">
                     <p-cellEditor>
                         <ng-template #input>
                             <input pInputText type="text" fluid />

--- a/scorekeeper/src/app/pages/cards/cards.ts
+++ b/scorekeeper/src/app/pages/cards/cards.ts
@@ -3,14 +3,17 @@ import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { CardsService } from '../../services/cards.service';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { ConfirmationService } from 'primeng/api';
+import { InputTextModule } from 'primeng/inputtext';
+import { Player } from './interfaces/cards.interface';
 
 @Component({
   selector: 'app-cards',
   imports: [
     TableModule,
     ButtonModule,
-    ConfirmDialogModule
+    ConfirmDialogModule,
+    InputTextModule
   ],
   providers: [ConfirmationService],
   templateUrl: './cards.html',
@@ -18,7 +21,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 })
 export class Cards implements OnInit {
 
-  public playerData: any = [];
+  public playerData: Player[] = [];
 
   constructor(
     public cardsService: CardsService,
@@ -63,5 +66,9 @@ export class Cards implements OnInit {
             reject: () => {
             },
         });
+  }
+
+  onEditComplete() {
+    this.cardsService.saveGameData(this.playerData);
   }
 }

--- a/scorekeeper/src/app/pages/cards/cards.ts
+++ b/scorekeeper/src/app/pages/cards/cards.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
-import { TableModule } from 'primeng/table';
+import { TableModule, TableEditCompleteEvent } from 'primeng/table';
 import { CardsService } from '../../services/cards.service';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ConfirmationService } from 'primeng/api';
@@ -68,7 +68,10 @@ export class Cards implements OnInit {
         });
   }
 
-  onEditComplete() {
+  onEditComplete(event: TableEditCompleteEvent) {
+    if (event.index !== undefined && event.data) {
+      this.playerData[event.index] = event.data as Player;
+    }
     this.cardsService.saveGameData(this.playerData);
   }
 }

--- a/scorekeeper/src/app/pages/cards/interfaces/cards.interface.ts
+++ b/scorekeeper/src/app/pages/cards/interfaces/cards.interface.ts
@@ -1,8 +1,8 @@
-interface CardsGame {
-    playerData: Player[]
+export interface CardsGame {
+    playerData: Player[];
 }
 
-interface Player {
+export interface Player {
     name: string;
     points: number;
     notes: string;

--- a/scorekeeper/src/app/services/cards.service.ts
+++ b/scorekeeper/src/app/services/cards.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { LocalStorageConfig } from '../configs/localStorage.config';
+import { CardsGame, Player } from '../pages/cards/interfaces/cards.interface';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
## Summary
- make card table cells editable for name, points, and notes
- persist edits to local storage using CardsService

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6894f66a41488329a66484a9d5448758